### PR TITLE
Facebookシェアボタンの表示が欠けているのを修正

### DIFF
--- a/docs/concert.html
+++ b/docs/concert.html
@@ -98,7 +98,6 @@
               </div>
             </div>
           </div>
-          -->
           <!-- shares -->
           <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>
           <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/docs/concert.html
+++ b/docs/concert.html
@@ -102,7 +102,7 @@
           <!-- shares -->
           <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>
           <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-          <iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftbsk-orch.com%2Fconcert.html&layout=button&size=small&width=61&height=20&appId" width="61" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+          <iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftbsk-orch.com%2Fconcert.html&layout=button&size=small" width="80" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
           <!-- /shares -->
         </div>
         <!-- /#conR -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
           <!-- shares -->
           <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>
           <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-          <iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftbsk-orch.com%2F&layout=button&size=small&width=61&height=20&appId" width="61" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+          <iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftbsk-orch.com%2F&layout=button&size=small" width="80" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
           <!-- /shares -->
         </div>
         <!-- /#conR -->

--- a/docs/video.html
+++ b/docs/video.html
@@ -53,7 +53,7 @@
           <!-- shares -->
           <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>
           <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-          <iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftbsk-orch.com%2Fconcert.html&layout=button&size=small&width=61&height=20&appId" width="61" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+          <iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftbsk-orch.com%2Fconcert.html&layout=button&size=small" width="80" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
           <!-- /shares -->
           <div id="playerContainer">読み込み中…</div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,30 @@
 {
+  "name": "tbsk-orch.com",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "name": "tbsk-orch.com",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "prettier": "^1.19.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
   "dependencies": {
     "prettier": {
       "version": "1.19.1",


### PR DESCRIPTION
Facebookシェアボタンの`width`が足りておらず表示が欠けていたので、`width`を増やしました。

ついでに、以下の修正を行いました。

- Facebookシェアボタンのiframeのsrcから不要そうなクエリパラメータを削除
  + [ドキュメント](https://developers.facebook.com/docs/plugins/share-button#settings)を見る限り、`width`,`height`などの指定はサポートされていないようです
- concert.htmlに余計な`-->`があったので削除
- package-lock.jsonを新バージョン(`"lockfileVersion": 2`)のもので上書き
  + 今`npm install`したら勝手に更新されたので…